### PR TITLE
Use correct FE URL

### DIFF
--- a/src/Routes.php
+++ b/src/Routes.php
@@ -26,7 +26,7 @@ class Routes extends AbstractEndpoint {
 	public function endpoint_callback( \WP_REST_Request $request ) {
 		$data = [];
 
-		$site_url = site_url();
+		$site_url = home_url();
 
 		// Create a route for each page.
 		$pages_query = new \WP_Query([


### PR DESCRIPTION
Since `site_url()` gives the value of the WP installation and `home_url` returns the FE of the site we need to replace the FE URL not the BE.
